### PR TITLE
Add coverage report to testing

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
 
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm test:coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "------ TESTING  ------": "",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
     "------ LINTING  ------": "",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",


### PR DESCRIPTION
A new script named "test:coverage" has been added to the package.json file to generate coverage reports using jest. The workflow in codecov.yml has been updated to run this script, ensuring coverage reports will be generated each time tests run.