### PR TITLE
Add coverage collection configuration in Jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -27,6 +27,7 @@ const config = {
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
     },
+    collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
 };
 
 module.exports = config;


### PR DESCRIPTION
An additional line was added in the Jest configuration file to collect coverage from all TypeScript files while excluding definition files. This addition ensures our tests also examine the code coverage of our actual TypeScript code, not just the definitions.