### PR TITLE
Update GitHub action to create PR on template update

### DIFF
--- a/.github/workflows/update-from-template.yml
+++ b/.github/workflows/update-from-template.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   update-and-create-pr:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout develop branch
         uses: actions/checkout@v4


### PR DESCRIPTION
The GitHub action now has been updated to create a new branch for template updates and generate a Pull Request after updating from the template repository. This will enhance visibility and allow review before merging changes from the template repository into the main codebase.