### PR TITLE
Add '@golevelup/ts-jest' dependency and refactor decorators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+        env:
+          JWT_SECRET: "TESTING"
+          TOKEN_ACCCESS_SECRET: "TESTING"
+          TOKEN_REFRESH_SECRET: "TESTING"
+          TOKEN_VERIFICATION_SECRET: "TESTING"
+          TOKEN_RESET_PASSWORD_SECRET: "TESTING"
 
       - name: Run dry build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: pnpm test
         env:
           JWT_SECRET: "TESTING"
-          TOKEN_ACCCESS_SECRET: "TESTING"
+          TOKEN_ACCESS_SECRET: "TESTING"
           TOKEN_REFRESH_SECRET: "TESTING"
           TOKEN_VERIFICATION_SECRET: "TESTING"
           TOKEN_RESET_PASSWORD_SECRET: "TESTING"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@elsikora/eslint-plugin-sort-decorators": "0.2.8",
     "@faker-js/faker": "8.4.1",
+    "@golevelup/ts-jest": "^0.5.0",
     "@nestjs/jwt": "10.2.0",
     "@nestjs/testing": "10.3.9",
     "@swc/jest": "0.2.36",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@faker-js/faker':
         specifier: 8.4.1
         version: 8.4.1
+      '@golevelup/ts-jest':
+        specifier: ^0.5.0
+        version: 0.5.0
       '@nestjs/jwt':
         specifier: 10.2.0
         version: 10.2.0(@nestjs/common@10.3.9(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))
@@ -595,6 +598,9 @@ packages:
   '@faker-js/faker@8.4.1':
     resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+
+  '@golevelup/ts-jest@0.5.0':
+    resolution: {integrity: sha512-UniUNOBraDD8vf6QNUPkpWMzhUXBtw40nCHekgBlaHy2p99MDV0aYLp4ZXifiyPOsFmg4BZQGs60lF6EpV7JpA==}
 
   '@grpc/grpc-js@1.10.10':
     resolution: {integrity: sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==}
@@ -5875,6 +5881,8 @@ snapshots:
   '@eslint/js@8.57.0': {}
 
   '@faker-js/faker@8.4.1': {}
+
+  '@golevelup/ts-jest@0.5.0': {}
 
   '@grpc/grpc-js@1.10.10':
     dependencies:

--- a/src/application/app.module.test.ts
+++ b/src/application/app.module.test.ts
@@ -1,0 +1,58 @@
+import { ScheduleModule } from '@nestjs/schedule';
+import { Test } from '@nestjs/testing';
+import { OpenTelemetryModule } from 'nestjs-otel';
+
+import { AppModule } from '@/application/app.module';
+import { AuthenticationModule } from '@/application/authentication/authentication.module';
+import { HealthModule } from '@/application/health/health.module';
+import { PingModule } from '@/application/ping/ping.module';
+import { SessionModule } from '@/application/session/session.module';
+import { UserModule } from '@/application/user/user.module';
+import { VerificationModule } from '@/application/verification/verification.module';
+import { CacheModule } from '@/infrastructure/cache/cache.module';
+import { ConfigModule } from '@/infrastructure/config/config.module';
+import { CqrsModule } from '@/infrastructure/cqrs/cqrs.module';
+import { LoggerModule } from '@/infrastructure/logger/logger.module';
+import { MailerModule } from '@/infrastructure/mailer/mailer.module';
+import { MockRepositoriesModule } from '@/infrastructure/repositories/presets/mock-repositories.module';
+import { RepositoriesModule } from '@/infrastructure/repositories/repositories.module';
+import { ThrottlerModule } from '@/infrastructure/throttler/throttler.module';
+import { TokenModule } from '@/infrastructure/token/token.module';
+
+describe('appModule', () => {
+    it('should compile the module', async () => {
+        const module = await Test.createTestingModule({
+            imports: [AppModule, MockRepositoriesModule],
+        }).compile();
+
+        expect(module).toBeDefined();
+        // Check if all modules are correctly imported
+        // System Modules
+        expect(module.get(CqrsModule)).toBeInstanceOf(CqrsModule); // CQRS Module for Command Query Responsibility Segregation
+        expect(module.get(ConfigModule)).toBeInstanceOf(ConfigModule); // Configuration Module
+        expect(module.get(CacheModule)).toBeInstanceOf(CacheModule); // Cache Module
+        expect(module.get(LoggerModule)).toBeInstanceOf(LoggerModule); // Logger Module
+        expect(module.get(ThrottlerModule)).toBeInstanceOf(ThrottlerModule); // Throttler Module
+        expect(module.get(RepositoriesModule)).toBeInstanceOf(
+            RepositoriesModule,
+        ); // Repositories Module
+        expect(module.get(ScheduleModule)).toBeInstanceOf(ScheduleModule); // Schedule Module for Cron Jobs
+        expect(module.get(OpenTelemetryModule)).toBeInstanceOf(
+            OpenTelemetryModule,
+        ); // OpenTelemetry Module for Tracing
+        expect(module.get(MailerModule)).toBeInstanceOf(MailerModule); // Email Module
+        expect(module.get(TokenModule)).toBeInstanceOf(TokenModule); // Token Module
+
+        // Application Modules
+        expect(module.get(HealthModule)).toBeInstanceOf(HealthModule); // Health Module
+        expect(module.get(PingModule)).toBeInstanceOf(PingModule); // Ping Module
+        expect(module.get(AuthenticationModule)).toBeInstanceOf(
+            AuthenticationModule,
+        ); // Authentication Module
+        expect(module.get(SessionModule)).toBeInstanceOf(SessionModule); // Session Module
+        expect(module.get(VerificationModule)).toBeInstanceOf(
+            VerificationModule,
+        ); // Verification Module
+        expect(module.get(UserModule)).toBeInstanceOf(UserModule); // User Module
+    });
+});

--- a/src/application/authentication/decorator/current-user.decorator.test.ts
+++ b/src/application/authentication/decorator/current-user.decorator.test.ts
@@ -1,0 +1,45 @@
+import { createMock } from '@golevelup/ts-jest';
+import { ExecutionContext } from '@nestjs/common';
+
+import { CurrentUserFactory } from '@/application/authentication/decorator/current-user.decorator';
+
+describe('current user decorator', () => {
+    it('should return the current user', () => {
+        // Mock user object
+        const user = { userId: '123', username: 'testUser' };
+
+        // Mock request object
+        const request = {
+            user,
+        };
+
+        // Mock ExecutionContext
+        const context = createMock<ExecutionContext>();
+        context.switchToHttp = jest.fn().mockReturnValue({
+            getRequest: () => request,
+        });
+
+        // Invoke CurrentUser decorator with mocked context
+        const result = CurrentUserFactory(null, context);
+
+        // Assert that the decorator returns the expected user object
+        expect(result).toBe(user);
+    });
+
+    it('should return undefined if the user is not present', () => {
+        // Mock request object
+        const request = {};
+
+        // Mock ExecutionContext
+        const context = createMock<ExecutionContext>();
+        context.switchToHttp = jest.fn().mockReturnValue({
+            getRequest: () => request,
+        });
+
+        // Invoke CurrentUser decorator with mocked context
+        const result = CurrentUserFactory(null, context);
+
+        // Assert that the decorator returns null
+        expect(result).toBeUndefined();
+    });
+});

--- a/src/application/authentication/decorator/current-user.decorator.ts
+++ b/src/application/authentication/decorator/current-user.decorator.ts
@@ -2,9 +2,9 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 import { RequestWithUser } from '@/types/express/request-with-user';
 
-export const CurrentUser = createParamDecorator(
-    (data: unknown, ctx: ExecutionContext) => {
-        const request = ctx.switchToHttp().getRequest<RequestWithUser>();
-        return request.user;
-    },
-);
+export const CurrentUserFactory = (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest<RequestWithUser>();
+    return request.user;
+};
+
+export const CurrentUser = createParamDecorator(CurrentUserFactory);

--- a/src/application/authentication/decorator/token.decorator.test.ts
+++ b/src/application/authentication/decorator/token.decorator.test.ts
@@ -1,0 +1,72 @@
+import { createMock } from '@golevelup/ts-jest';
+import { ExecutionContext } from '@nestjs/common';
+
+import { TokenFactory } from '@/application/authentication/decorator/token.decorator';
+
+describe('token decorator', () => {
+    it('should return the token', () => {
+        // Mock user object
+        const token = 'Bearer TestToken';
+
+        // Mock request object
+        const request = {
+            headers: {
+                authorization: token,
+            },
+        };
+
+        // Mock ExecutionContext
+        const context = createMock<ExecutionContext>();
+        context.switchToHttp = jest.fn().mockReturnValue({
+            getRequest: () => request,
+        });
+
+        // Invoke CurrentUser decorator with mocked context
+        const result = TokenFactory(null, context);
+
+        // Assert that the decorator returns the expected user object
+        expect(result).toBe('TestToken');
+    });
+
+    it('should return null if the token is not present', () => {
+        // Mock request object
+        const request = {
+            headers: {
+                authorization: null,
+            },
+        };
+
+        // Mock ExecutionContext
+        const context = createMock<ExecutionContext>();
+        context.switchToHttp = jest.fn().mockReturnValue({
+            getRequest: () => request,
+        });
+
+        // Invoke CurrentUser decorator with mocked context
+        const result = TokenFactory(null, context);
+
+        // Assert that the decorator returns the expected user object
+        expect(result).toBeNull();
+    });
+
+    it('should return null if the token is not valid', () => {
+        // Mock request object
+        const request = {
+            headers: {
+                authorization: 'Bearer ',
+            },
+        };
+
+        // Mock ExecutionContext
+        const context = createMock<ExecutionContext>();
+        context.switchToHttp = jest.fn().mockReturnValue({
+            getRequest: () => request,
+        });
+
+        // Invoke CurrentUser decorator with mocked context
+        const result = TokenFactory(null, context);
+
+        // Assert that the decorator returns the expected user object
+        expect(result).toBeNull();
+    });
+});

--- a/src/application/authentication/decorator/token.decorator.ts
+++ b/src/application/authentication/decorator/token.decorator.ts
@@ -1,23 +1,24 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
+import { CurrentUserFactory } from '@/application/authentication/decorator/current-user.decorator';
 import { RequestWithUser } from '@/types/express/request-with-user';
 
-export const Token = createParamDecorator(
-    (data: unknown, ctx: ExecutionContext) => {
-        const request = ctx.switchToHttp().getRequest<RequestWithUser>();
+export const TokenFactory = (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest<RequestWithUser>();
 
-        const authorization = request.headers.authorization;
+    const authorization = request.headers.authorization;
 
-        if (!authorization) {
-            return null;
-        }
+    if (!authorization) {
+        return null;
+    }
 
-        const token = authorization.split(' ')[1];
+    const token = authorization.split(' ')[1];
 
-        if (!token) {
-            return null;
-        }
+    if (!token) {
+        return null;
+    }
 
-        return token;
-    },
-);
+    return token;
+};
+
+export const Token = createParamDecorator(CurrentUserFactory);


### PR DESCRIPTION
The '@golevelup/ts-jest' dependency was added to support creation of mocks in tests. This also led to refactoring of 'CurrentUser' and 'Token' decorators from nest.js, where the factory functions have been separated for better testability. Moreover, test cases have been added for better code coverage.