### PR TITLE
Add test secrets to GitHub Actions workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -44,6 +44,12 @@ jobs:
 
       - name: Run tests
         run: pnpm test:coverage
+        env:
+          JWT_SECRET: "TESTING"
+          TOKEN_ACCESS_SECRET: "TESTING"
+          TOKEN_REFRESH_SECRET: "TESTING"
+          TOKEN_VERIFICATION_SECRET: "TESTING"
+          TOKEN_RESET_PASSWORD_SECRET: "TESTING"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1


### PR DESCRIPTION
This commit introduces JWT and token related secrets to the `.github/workflows/codecov.yml` file. These secrets are used for testing purposes and are set with the value "TESTING". The addition will help ensure tests involving token generation or verification can successfully run in the GitHub Actions environment.