### PR TITLE
Replace @ApiOperation with @ApiOperationWithRoles

### DIFF
--- a/src/application/authentication/v1/commands/logout/logout.http.controller.ts
+++ b/src/application/authentication/v1/commands/logout/logout.http.controller.ts
@@ -1,10 +1,11 @@
 import { Controller, HttpCode, Post, Req, UseGuards } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 import { Public } from '@/application/authentication/decorator/public.decorator';
 import { RefreshTokenGuard } from '@/application/authentication/strategies/refresh-token/refresh-token.guard';
 import { V1RevokeSessionCommandHandler } from '@/application/session/v1/commands/revoke-session/revoke-session.handler';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 import type { RequestWithUser } from '@/types/express/request-with-user';
 
@@ -15,7 +16,7 @@ import type { RequestWithUser } from '@/types/express/request-with-user';
 export class V1LogoutController {
     constructor(private readonly commandBus: CommandBus) {}
 
-    @ApiOperation({
+    @ApiOperationWithRoles({
         summary: 'Logout a User Account and invalidate the refresh token',
     }) // This is to bypass the AccessTokenGuard
     @ApiSecurity('refresh-token')

--- a/src/application/authentication/v1/commands/refresh/refresh.http.controller.ts
+++ b/src/application/authentication/v1/commands/refresh/refresh.http.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, HttpCode, Post, Req, UseGuards } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '@/application/authentication/decorator/current-user.decorator';
 import { Public } from '@/application/authentication/decorator/public.decorator';
 import { RefreshTokenGuard } from '@/application/authentication/strategies/refresh-token/refresh-token.guard';
 import { V1RefreshTokenCommandHandler } from '@/application/authentication/v1/commands/refresh/refresh.handler';
 import { User } from '@/domain/user/user.entity';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 import type { RequestWithUser } from '@/types/express/request-with-user';
 
@@ -19,7 +20,7 @@ import { V1RefreshTokenResponseDto } from './dto/refresh.response.dto';
 export class V1RefreshTokenController {
     constructor(private readonly commandBus: CommandBus) {}
 
-    @ApiOperation({
+    @ApiOperationWithRoles({
         summary:
             'RefreshToken to a User Account and get access and refresh token',
     }) // This is to bypass the AccessTokenGuard

--- a/src/application/session/v1/commands/revoke-session/revoke-session.http.controller.ts
+++ b/src/application/session/v1/commands/revoke-session/revoke-session.http.controller.ts
@@ -6,11 +6,12 @@ import {
     UnauthorizedException,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '@/application/authentication/decorator/current-user.decorator';
 import { User } from '@/domain/user/user.entity';
 import { UserRoleEnum } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 
 import { V1FindSessionByTokenQueryHandler } from '../../queries/find-session-by-token/find-session-by-token.handler';
@@ -29,8 +30,10 @@ export class V1RevokeSessionController {
         private readonly commandBus: CommandBus,
     ) {}
 
-    @ApiOperation({
+    @ApiOperationWithRoles({
         summary: 'Revoke Session',
+        description:
+            "If User's Roles is User, the session must be owned by the User.",
     })
     @ApiStandardisedResponse(
         {

--- a/src/application/session/v1/queries/find-all-sessions-by-user/find-all-sessions-by-user.http.controller.ts
+++ b/src/application/session/v1/queries/find-all-sessions-by-user/find-all-sessions-by-user.http.controller.ts
@@ -7,11 +7,12 @@ import {
     UnauthorizedException,
 } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '@/application/authentication/decorator/current-user.decorator';
 import { User } from '@/domain/user/user.entity';
 import { UserRoleEnum } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 
 import { V1FindUserByIDQueryHandler } from '../../../../user/v1/queries/find-user-by-id/find-user-by-id.handler';
@@ -31,8 +32,10 @@ export class V1FindAllSessionsByUserController {
 
     constructor(private readonly queryBus: QueryBus) {}
 
-    @ApiOperation({
+    @ApiOperationWithRoles({
         summary: 'Find all Sessions By user',
+        description:
+            "If User's Roles is User, the session must be owned by the User.",
     })
     @ApiStandardisedResponse(
         {

--- a/src/application/session/v1/queries/find-session-by-token/find-session-by-token.http.controller.ts
+++ b/src/application/session/v1/queries/find-session-by-token/find-session-by-token.http.controller.ts
@@ -7,11 +7,12 @@ import {
     UnauthorizedException,
 } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '@/application/authentication/decorator/current-user.decorator';
 import { User } from '@/domain/user/user.entity';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 
 import { V1FindSessionByTokenResponseDto } from './dto/find-session-by-token.response.dto';
@@ -27,8 +28,10 @@ export class V1FindSessionByTokenController {
 
     constructor(private readonly queryBus: QueryBus) {}
 
-    @ApiOperation({
+    @ApiOperationWithRoles({
         summary: 'Find Session By Token',
+        description:
+            "If User's Roles is User, the session must be owned by the User.",
     })
     @ApiStandardisedResponse(
         {

--- a/src/application/user/v1/commands/create-user/create-user.http.controller.ts
+++ b/src/application/user/v1/commands/create-user/create-user.http.controller.ts
@@ -1,11 +1,11 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { generate as generatePassword } from 'generate-password';
 
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { User } from '@/domain/user/user.entity';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 
 import { V1CreateUserCommand } from './create-user.command';
@@ -20,11 +20,14 @@ import { V1CreateUserResponseDto } from './dto/create-user.response.dto';
 export class V1CreateUserController {
     constructor(private readonly commandBus: CommandBus) {}
 
-    @ApiOperation({
-        summary: 'Creates a User',
-        description:
-            'Requires the user to be an write admin. Creates a new User with the provided data. The password is randomly generated and returned in the response.',
-    })
+    @ApiOperationWithRoles(
+        {
+            summary: 'Creates a User',
+            description:
+                'Requires the user to be an write admin. Creates a new User with the provided data. The password is randomly generated and returned in the response.',
+        },
+        AllStaffRoles,
+    )
     @ApiStandardisedResponse(
         {
             status: 201,
@@ -33,7 +36,6 @@ export class V1CreateUserController {
         V1CreateUserResponseDto,
     )
     @Post('/user')
-    @Roles(...AllStaffRoles)
     async createUser(
         @Body() body: V1CreateUserRequestDto,
     ): Promise<V1CreateUserResponseDto> {

--- a/src/application/user/v1/commands/delete-user/delete-user.http.controller.ts
+++ b/src/application/user/v1/commands/delete-user/delete-user.http.controller.ts
@@ -1,10 +1,10 @@
 import { BadRequestException, Controller, Delete, Param } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { V1DeleteUserResponseDto } from '@/application/user/v1/commands/delete-user/dto/delete-user.response.dto';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 import { GenericInternalValidationException } from '@/shared/exceptions/internal-validation.exception';
 import { GenericNotFoundException } from '@/shared/exceptions/not-found.exception';
@@ -24,11 +24,14 @@ export class V1DeleteUserController {
         private readonly queryBus: QueryBus,
     ) {}
 
-    @ApiOperation({
-        summary: 'Delete a user',
-        description:
-            'Delete the user with the given ID. This action is irreversible.',
-    })
+    @ApiOperationWithRoles(
+        {
+            summary: 'Delete a user',
+            description:
+                'Delete the user with the given ID. This action is irreversible.',
+        },
+        AllStaffRoles,
+    )
     @ApiStandardisedResponse(
         {
             status: 200,
@@ -44,7 +47,6 @@ export class V1DeleteUserController {
         undefined,
     )
     @Delete('/user/:id')
-    @Roles(...AllStaffRoles)
     async deleteUser(
         @Param('id') id: string,
     ): Promise<V1DeleteUserResponseDto> {

--- a/src/application/user/v1/commands/update-user/update-user.http.controller.ts
+++ b/src/application/user/v1/commands/update-user/update-user.http.controller.ts
@@ -6,11 +6,11 @@ import {
     Put,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { V1UpdateUserResponseDto } from '@/application/user/v1/commands/update-user/dto/update-user.response.dto';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 import { GenericInternalValidationException } from '@/shared/exceptions/internal-validation.exception';
 import { GenericNotFoundException } from '@/shared/exceptions/not-found.exception';
@@ -31,11 +31,14 @@ export class V1UpdateUserController {
         private readonly queryBus: QueryBus,
     ) {}
 
-    @ApiOperation({
-        summary: 'Updates the  for a user',
-        description:
-            'Updates the  for a user, but if you are a "USER" role you can only edit your own user id',
-    })
+    @ApiOperationWithRoles(
+        {
+            summary: 'Updates the for a user',
+            description:
+                'Updates the  for a user, but if you are a "USER" role you can only edit your own user id',
+        },
+        AllStaffRoles,
+    )
     @ApiStandardisedResponse(
         {
             status: 200,
@@ -55,7 +58,6 @@ export class V1UpdateUserController {
         undefined,
     )
     @Put('/user/:id')
-    @Roles(...AllStaffRoles)
     async updateUser(
         @Param('id') id: string,
         @Body() body: V1UpdateUserRequestDto,

--- a/src/application/user/v1/queries/find-all-users/find-all-users.http.controller.ts
+++ b/src/application/user/v1/queries/find-all-users/find-all-users.http.controller.ts
@@ -1,10 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { V1FindAllUsersQueryHandler } from '@/application/user/v1/queries/find-all-users/find-all-users.handler';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 
 import { V1FindAllUsersResponseDto } from './dto/find-all-users.response.dto';
@@ -16,10 +16,13 @@ import { V1FindAllUsersResponseDto } from './dto/find-all-users.response.dto';
 export class V1FindAllUsersController {
     constructor(private readonly queryBus: QueryBus) {}
 
-    @ApiOperation({
-        summary: 'Find all Users',
-        description: 'Requires the user to be an read admin.',
-    })
+    @ApiOperationWithRoles(
+        {
+            summary: 'Find all Users',
+            description: 'Requires the user to be an read admin.',
+        },
+        AllStaffRoles,
+    )
     @ApiStandardisedResponse(
         {
             status: 200,
@@ -32,7 +35,6 @@ export class V1FindAllUsersController {
         description: 'The User could not be found.',
     })
     @Get('/user')
-    @Roles(...AllStaffRoles)
     async findAllUsers(): Promise<V1FindAllUsersResponseDto> {
         const users = await V1FindAllUsersQueryHandler.runHandler(
             this.queryBus,

--- a/src/application/user/v1/queries/find-current-user/find-current-user.http.controller.ts
+++ b/src/application/user/v1/queries/find-current-user/find-current-user.http.controller.ts
@@ -1,11 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '@/application/authentication/decorator/current-user.decorator';
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { User } from '@/domain/user/user.entity';
-import { UserRoleEnum } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 
 import { V1FindCurrentUserResponseDto } from './dto/find-current-user.response.dto';
@@ -17,7 +16,7 @@ import { V1FindCurrentUserResponseDto } from './dto/find-current-user.response.d
 export class V1FindCurrentUserController {
     constructor(private readonly queryBus: QueryBus) {}
 
-    @ApiOperation({
+    @ApiOperationWithRoles({
         summary: 'Find Current',
     })
     @ApiStandardisedResponse(
@@ -28,7 +27,6 @@ export class V1FindCurrentUserController {
         V1FindCurrentUserResponseDto,
     )
     @Get('/user/me')
-    @Roles(UserRoleEnum.USER)
     findCurrentUser(
         @CurrentUser() user: User,
     ): Promise<V1FindCurrentUserResponseDto> {

--- a/src/application/user/v1/queries/find-user-by-email/find-user-by-email.http.controller.ts
+++ b/src/application/user/v1/queries/find-user-by-email/find-user-by-email.http.controller.ts
@@ -1,11 +1,11 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { V1FindUserByEmailParamDto } from '@/application/user/v1/queries/find-user-by-email/dto/find-user-by-email.param.dto';
 import { V1FindUserByEmailQueryHandler } from '@/application/user/v1/queries/find-user-by-email/find-user-by-email.handler';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 import { GenericNotFoundException } from '@/shared/exceptions/not-found.exception';
 
@@ -18,10 +18,13 @@ import { V1FindUserByEmailResponseDto } from './dto/find-user-by-email.response.
 export class V1FindUserByEmailController {
     constructor(private readonly queryBus: QueryBus) {}
 
-    @ApiOperation({
-        summary: 'Find User by Email',
-        description: 'Requires the user to be an read admin.',
-    })
+    @ApiOperationWithRoles(
+        {
+            summary: 'Find User by Email',
+            description: 'Requires the user to be an read admin.',
+        },
+        AllStaffRoles,
+    )
     @ApiStandardisedResponse(
         {
             status: 200,
@@ -34,7 +37,6 @@ export class V1FindUserByEmailController {
         description: 'The User could not be found.',
     })
     @Get('/user/email/:email')
-    @Roles(...AllStaffRoles)
     async findUserById(
         @Param() params: V1FindUserByEmailParamDto,
     ): Promise<V1FindUserByEmailResponseDto> {

--- a/src/application/user/v1/queries/find-user-by-id/find-user-by-id.http.controller.ts
+++ b/src/application/user/v1/queries/find-user-by-id/find-user-by-id.http.controller.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
-import { Roles } from '@/application/authentication/decorator/roles.decorator';
 import { AllStaffRoles } from '@/domain/user/user-role.enum';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
 import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
 import { GenericNotFoundException } from '@/shared/exceptions/not-found.exception';
 
@@ -18,10 +18,13 @@ import { V1FindUserByIDQuery } from './find-user-by-id.query';
 export class V1FindUserByIDController {
     constructor(private readonly queryBus: QueryBus) {}
 
-    @ApiOperation({
-        summary: 'Find User by ID',
-        description: 'Requires the user to be an read admin.',
-    })
+    @ApiOperationWithRoles(
+        {
+            summary: 'Find User by ID',
+            description: 'Requires the user to be an read admin.',
+        },
+        AllStaffRoles,
+    )
     @ApiStandardisedResponse(
         {
             status: 200,
@@ -34,7 +37,6 @@ export class V1FindUserByIDController {
         description: 'The User could not be found.',
     })
     @Get('/user/:id')
-    @Roles(...AllStaffRoles)
     async findUserById(
         @Param('id') id: string,
     ): Promise<V1FindUserByIDResponseDto> {

--- a/src/shared/decorator/api-operation-with-roles.decorator.ts
+++ b/src/shared/decorator/api-operation-with-roles.decorator.ts
@@ -1,0 +1,17 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiOperationOptions } from '@nestjs/swagger';
+
+import { Roles } from '@/application/authentication/decorator/roles.decorator';
+import { UserRoleEnum } from '@/domain/user/user-role.enum';
+
+export const ApiOperationWithRoles = (
+    options: ApiOperationOptions,
+    roles: UserRoleEnum[] = [...Object.values(UserRoleEnum)],
+) =>
+    applyDecorators(
+        ApiOperation({
+            ...options,
+            summary: `${options.summary ?? 'Unknown'} - Roles: ${roles.join(', ')}`,
+        }),
+        Roles(...roles),
+    );


### PR DESCRIPTION
Refactor multiple controllers to use the new @ApiOperationWithRoles decorator for more efficient role-based API documentation. Removed redundant @Roles decorators and integrated role information within the @ApiOperationWithRoles decorator.