### PR TITLE
Add controllers for session queries by current user

### DIFF
--- a/src/application/session/v1/queries/find-all-sessions-by-current-user/dto/find-all-sessions-by-current-user.response.dto.ts
+++ b/src/application/session/v1/queries/find-all-sessions-by-current-user/dto/find-all-sessions-by-current-user.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Session } from '@/domain/session/session.entity';
+
+export class V1FindAllSessionsByCurrentUserResponseDto {
+    @ApiProperty({
+        description: 'The Sessions that was Found',
+        type: [Session],
+    })
+    sessions!: Session[];
+}

--- a/src/application/session/v1/queries/find-all-sessions-by-current-user/find-all-sessions-by-current-user.http.controller.ts
+++ b/src/application/session/v1/queries/find-all-sessions-by-current-user/find-all-sessions-by-current-user.http.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Logger } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { ApiTags } from '@nestjs/swagger';
+
+import { CurrentUser } from '@/application/authentication/decorator/current-user.decorator';
+import { V1FindAllSessionsByUserQueryHandler } from '@/application/session/v1/queries/find-all-sessions-by-user/find-all-sessions-by-user.handler';
+import { User } from '@/domain/user/user.entity';
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
+import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
+
+import { V1FindAllSessionsByCurrentUserResponseDto } from './dto/find-all-sessions-by-current-user.response.dto';
+
+@ApiTags('Session')
+@Controller({
+    version: '1',
+})
+export class V1FindAllSessionsByCurrentUserController {
+    private readonly logger = new Logger(
+        V1FindAllSessionsByCurrentUserController.name,
+    );
+
+    constructor(private readonly queryBus: QueryBus) {}
+
+    @ApiOperationWithRoles({
+        summary: 'Find all Sessions By current user',
+    })
+    @ApiStandardisedResponse(
+        {
+            status: 200,
+            description: 'The Sessions has been successfully found.',
+        },
+        V1FindAllSessionsByCurrentUserResponseDto,
+    )
+    @Get('/session/user/me')
+    async findSessionByCurrentUser(
+        @CurrentUser() currentUser: User,
+    ): Promise<V1FindAllSessionsByCurrentUserResponseDto> {
+        const sessions = await V1FindAllSessionsByUserQueryHandler.runHandler(
+            this.queryBus,
+            {
+                user: currentUser,
+            },
+        );
+
+        return { sessions };
+    }
+}

--- a/src/application/session/v1/queries/find-current-session/dto/find-current-session.response.dto.ts
+++ b/src/application/session/v1/queries/find-current-session/dto/find-current-session.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Session } from '@/domain/session/session.entity';
+
+export class V1FindCurrentSessionResponseDto {
+    @ApiProperty({
+        description: 'The Session that was Found',
+        type: Session,
+    })
+    session!: Session;
+}

--- a/src/application/session/v1/queries/find-current-session/find-current-session.http.controller.ts
+++ b/src/application/session/v1/queries/find-current-session/find-current-session.http.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Logger, Request } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiOperationWithRoles } from '@/shared/decorator/api-operation-with-roles.decorator';
+import { ApiStandardisedResponse } from '@/shared/decorator/api-standardised-response.decorator';
+import type { RequestWithUser } from '@/types/express/request-with-user';
+
+import { V1FindCurrentSessionResponseDto } from './dto/find-current-session.response.dto';
+
+@ApiTags('Session')
+@Controller({
+    version: '1',
+})
+export class V1FindCurrentSessionController {
+    private readonly logger = new Logger(V1FindCurrentSessionController.name);
+
+    constructor(private readonly queryBus: QueryBus) {}
+
+    @ApiOperationWithRoles({
+        summary: 'Find Current Session',
+    })
+    @ApiStandardisedResponse(
+        {
+            status: 200,
+            description: 'The Session has been successfully found.',
+        },
+        V1FindCurrentSessionResponseDto,
+    )
+    @Get('/session/me')
+    findCurrentSession(
+        @Request() req: RequestWithUser,
+    ): Promise<V1FindCurrentSessionResponseDto> {
+        return Promise.resolve({ session: req.session });
+    }
+}

--- a/src/application/session/v1/v1-session.module.ts
+++ b/src/application/session/v1/v1-session.module.ts
@@ -3,8 +3,10 @@ import { Module, Type } from '@nestjs/common';
 import { V1CreateSessionCommandHandler } from '@/application/session/v1/commands/create-session/create-session.handler';
 import { V1RevokeSessionCommandHandler } from '@/application/session/v1/commands/revoke-session/revoke-session.handler';
 import { V1RevokeSessionController } from '@/application/session/v1/commands/revoke-session/revoke-session.http.controller';
+import { V1FindAllSessionsByCurrentUserController } from '@/application/session/v1/queries/find-all-sessions-by-current-user/find-all-sessions-by-current-user.http.controller';
 import { V1FindAllSessionsByUserQueryHandler } from '@/application/session/v1/queries/find-all-sessions-by-user/find-all-sessions-by-user.handler';
 import { V1FindAllSessionsByUserController } from '@/application/session/v1/queries/find-all-sessions-by-user/find-all-sessions-by-user.http.controller';
+import { V1FindCurrentSessionController } from '@/application/session/v1/queries/find-current-session/find-current-session.http.controller';
 import { V1FindSessionByTokenQueryHandler } from '@/application/session/v1/queries/find-session-by-token/find-session-by-token.handler';
 import { V1FindSessionByTokenController } from '@/application/session/v1/queries/find-session-by-token/find-session-by-token.http.controller';
 
@@ -21,6 +23,8 @@ const queryHandlers: Type[] = [
 ];
 
 const queryControllers: Type[] = [
+    V1FindCurrentSessionController,
+    V1FindAllSessionsByCurrentUserController,
     V1FindAllSessionsByUserController,
     V1FindSessionByTokenController,
 ];

--- a/src/domain/session/session.dto.ts
+++ b/src/domain/session/session.dto.ts
@@ -16,8 +16,7 @@ export const SessionToken = () =>
     applyDecorators(
         ApiProperty({
             description: 'The token of the session',
-            example:
-                "export type CreateSessionProps = Omit<SessionProps, 'token' | 'isRevoked'>;",
+            example: 'jokemgtxc2pb7flis7v6ln8l',
             type: String,
             required: true,
         }),


### PR DESCRIPTION
Implemented `V1FindAllSessionsByCurrentUserController` and `V1FindCurrentSessionController` to enable querying sessions for the current user. This includes adding the respective response DTOs and updating the session module to register these new controllers.